### PR TITLE
Update JKube (kubernetes|openshift)-maven-plugin to 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ You could check that operators are successfully registered with the following co
 ❯ kubectl get csv
 NAME                                             DISPLAY                      VERSION              REPLACES                           PHASE
 apicurio-registry-operator.v1.0.0-v2.0.0.final   Apicurio Registry Operator   1.0.0-v2.0.0.final                                      Succeeded
-strimzi-cluster-operator.v0.23.0                 Strimzi                      0.23.0               strimzi-cluster-operator.v0.22.1   Succeeded
+strimzi-cluster-operator.v0.24.0                 Strimzi                      0.24.0               strimzi-cluster-operator.v0.23.0   Succeeded
 ```
 
 or verify the pods are running:
@@ -157,7 +157,7 @@ or verify the pods are running:
 ❯ kubectl get pod
 NAME                                              READY   STATUS    RESTARTS   AGE
 apicurio-registry-operator-598fff6985-xplll       1/1     Running   0          47m
-strimzi-cluster-operator-v0.23.0-9d5c6b6d-qqxjx   1/1     Running   0          47m
+strimzi-cluster-operator-v0.24.0-9d5c6b6d-qqxjx   1/1     Running   0          47m
 ```
 
 For more information about how to install Operators using the CLI command, please review this [article](
@@ -221,8 +221,8 @@ kafkatopic.kafka.strimzi.io/kafkasql-journal created
 apicurioregistry.apicur.io/service-registry created
 ```
 
-A new DeploymentConfig is created with the prefix ```service-registry-deployment-``` and a new route is
-created with the prefix ```service-registry-ingres-```. We must inspect it
+A new Deployment/DeploymentConfig is created with the prefix ```service-registry-deployment-``` and a new route is
+created with the prefix ```service-registry-ingress-```. We must inspect it
 to get the route created to expose the Service Registry API.
 
 In Kubernetes we will use an ingress entry based with ```NodePort```. To get the ingress entry:

--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
 					<plugin>
 						<groupId>org.eclipse.jkube</groupId>
 						<artifactId>openshift-maven-plugin</artifactId>
-						<version>1.0.0</version>
+						<version>1.3.0</version>
 					</plugin>
 				</plugins>
 			</build>
@@ -240,7 +240,7 @@
 					<plugin>
 						<groupId>org.eclipse.jkube</groupId>
 						<artifactId>kubernetes-maven-plugin</artifactId>
-						<version>1.0.0</version>
+						<version>1.3.0</version>
 					</plugin>
 				</plugins>
 			</build>


### PR DESCRIPTION
Update JKube to latest release version.

I tried to follow the README, but was unsuccessful to deploy Strimzi with OLM on Minikube.
Tried with vanilla installation of Strimzi Operator (`kubectl create -f 'https://strimzi.io/install/latest?namespace=kafka' -n kafka`), but the Kafka resources are based on `v1beta1` instead of `v1beta2`.
Maybe the README and resources should be updated too.
